### PR TITLE
一覧表示機能の作成（コントローラー・ビュー）

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,12 +128,13 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+
+      <% @items.each do | item |%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+           <%= image_tag item.image, class: "item-img" %> 
+          
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -143,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= SendDay.find(item.send_day_id).name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +156,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+     <%# itemモデルにデータがない場合に表示 %>
+      <% unless Item.exists? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,10 +177,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
+  <%# /itemモデルにデータがない場合に表示 %>
   <%# /商品一覧 %>
 </div>
 <%= link_to('/items/new', class: 'purchase-btn') do %>


### PR DESCRIPTION
# What
一覧表示機能の作成

# Why
出品者が出品した商品を一覧で表示することで、
購入者が希望する商品にたどり着けるようにするため

## Gyazo URL

・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/ed389dcfecf5ea5b2dcf0a34387e6d02

・商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/786e67c77a3675cf48e18ed1edc029d1


＊ルボコップを実行しましたが、修正箇所がなかったためルボコップ実行のコミットはしておりません。